### PR TITLE
Constructor should not be public

### DIFF
--- a/util-jme3-lemur/src/main/java/com/nx/util/jme3/lemur/panel/ViewportPanel.java
+++ b/util-jme3-lemur/src/main/java/com/nx/util/jme3/lemur/panel/ViewportPanel.java
@@ -180,7 +180,7 @@ public class ViewportPanel extends Panel {
         setStateManager(stateManager);
     }
 
-    public ViewportPanel(ElementId elementid, String style) {
+    protected ViewportPanel(ElementId elementid, String style) {
         super(elementid, style);
 
         viewPortNode = new Node("Root Node ViewPort Panel");


### PR DESCRIPTION
If this constructor is called while creating a ViewPortPanel it will always crash as no stateManager is available